### PR TITLE
Add support for dynamic key detection during decryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,27 @@ plaintext = JWE.decrypt(encrypted, key)
 puts plaintext #"The quick brown fox jumps over the lazy dog."
 ```
 
+This example sets an extra header and then uses it to detect the key during decryption.
+
+```ruby
+require 'jwe'
+
+keys = {
+  'id-1' => OpenSSL::PKey::RSA.generate(2048),
+  'id-2' => OpenSSL::PKey::RSA.generate(2048)
+}
+payload = "The quick brown fox jumps over the lazy dog."
+
+encrypted = JWE.encrypt(payload, keys['id-2'], headers: {kid: 'id-2'})
+puts encrypted
+
+plaintext = JWE.decrypt(encrypted, nil) do |headers|
+  kid = headers['kid']
+  keys[kid]
+end
+puts plaintext #"The quick brown fox jumps over the lazy dog."
+```
+
 ## Available Algorithms
 
 The RFC 7518 JSON Web Algorithms (JWA) spec defines the algorithms for [encryption](https://tools.ietf.org/html/rfc7518#section-5.1)

--- a/spec/jwe_spec.rb
+++ b/spec/jwe_spec.rb
@@ -28,6 +28,27 @@ describe JWE do
     end
   end
 
+  describe 'when using extra headers' do
+    it 'roundtrips' do
+      encrypted = JWE.encrypt(plaintext, rsa_key, headers: {kid: 'some-kid-1'})
+      result = JWE.decrypt(encrypted, rsa_key)
+      header, _ = JWE::Serialization::Compact.decode(encrypted)
+      header = JSON.parse(header)
+
+      expect(header['kid']).to eq 'some-kid-1'
+      expect(result).to eq plaintext
+    end
+
+    it 'allows dynamic key detection' do
+      encrypted = JWE.encrypt(plaintext, rsa_key)
+      result = JWE.decrypt(encrypted, nil) do |header|
+        rsa_key
+      end
+
+      expect(result).to eq plaintext
+    end
+  end
+
   it 'raises when passed a bad alg' do
     expect { JWE.encrypt(plaintext, rsa_key, alg: 'TEST') }.to raise_error(ArgumentError)
   end


### PR DESCRIPTION
This change adds 2 related things:

* Allows arbitrary headers to be added during encryption. This allows any variety of things, including (but not limited to) any of the various key-identifying headers defined in the JWE spec.

* Allows a block to be given to dynamically determine what key to use during decryption. The block is given the headers, allowing use of whatever key-identifying header may have been set during encryption. The implementation of this is very similar to dynamic key detection in ruby-jwt, making it easy to use both.

An example has been added to the README which should explain how to use both together.