### PR TITLE
Correct naming of class files so they can be loaded

### DIFF
--- a/lib/jwe/alg/a128_kw.rb
+++ b/lib/jwe/alg/a128_kw.rb
@@ -3,7 +3,7 @@ require 'jwe/alg/aes_kw'
 module JWE
   module Alg
     # AES-128 Key Wrapping algorithm
-    class A128Kw
+    class A128kw
       include AesKw
 
       def cipher_name

--- a/lib/jwe/alg/a192_kw.rb
+++ b/lib/jwe/alg/a192_kw.rb
@@ -3,7 +3,7 @@ require 'jwe/alg/aes_kw'
 module JWE
   module Alg
     # AES-192 Key Wrapping algorithm
-    class A192Kw
+    class A192kw
       include AesKw
 
       def cipher_name

--- a/lib/jwe/alg/a256_kw.rb
+++ b/lib/jwe/alg/a256_kw.rb
@@ -3,7 +3,7 @@ require 'jwe/alg/aes_kw'
 module JWE
   module Alg
     # AES-256 Key Wrapping algorithm
-    class A256Kw
+    class A256kw
       include AesKw
 
       def cipher_name

--- a/spec/jwe/alg_spec.rb
+++ b/spec/jwe/alg_spec.rb
@@ -69,9 +69,9 @@ describe JWE::Alg::Rsa15 do
 end
 
 [
-  JWE::Alg::A128Kw,
-  JWE::Alg::A192Kw,
-  JWE::Alg::A256Kw
+  JWE::Alg::A128kw,
+  JWE::Alg::A192kw,
+  JWE::Alg::A256kw
 ].each_with_index do |klass, i|
   describe klass do
     let(:kek) { SecureRandom.random_bytes(16 + i * 8) }


### PR DESCRIPTION
A[128,192,256]KW get transformed to A[128,192,256]kw by JWE.param_to_class_name class function, so existing classes with capital K are not found when they should be.