### PR TITLE
Generalize api

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ payload = "The quick brown fox jumps over the lazy dog."
 encrypted = JWE.encrypt(payload, key)
 puts encrypted
 
-plaintext = JWE.decrypt(encrypted, key)
+plaintext, header = JWE.decrypt(encrypted, key)
 puts plaintext #"The quick brown fox jumps over the lazy dog."
 ```
 
@@ -39,7 +39,7 @@ payload = "The quick brown fox jumps over the lazy dog."
 encrypted = JWE.encrypt(payload, key, enc: 'A192GCM')
 puts encrypted
 
-plaintext = JWE.decrypt(encrypted, key)
+plaintext, header = JWE.decrypt(encrypted, key)
 puts plaintext #"The quick brown fox jumps over the lazy dog."
 ```
 
@@ -54,7 +54,7 @@ payload = "The quick brown fox jumps over the lazy dog."
 encrypted = JWE.encrypt(payload, key, alg: 'dir')
 puts encrypted
 
-plaintext = JWE.decrypt(encrypted, key)
+plaintext, header = JWE.decrypt(encrypted, key)
 puts plaintext #"The quick brown fox jumps over the lazy dog."
 ```
 
@@ -69,7 +69,7 @@ payload = "The quick brown fox jumps over the lazy dog."
 encrypted = JWE.encrypt(payload, key, zip: 'DEF')
 puts encrypted
 
-plaintext = JWE.decrypt(encrypted, key)
+plaintext, header = JWE.decrypt(encrypted, key)
 puts plaintext #"The quick brown fox jumps over the lazy dog."
 ```
 
@@ -83,8 +83,11 @@ payload = "The quick brown fox jumps over the lazy dog."
 
 # In this case we add a copyright line to the headers (it can be anything you like
 # just remember it is plaintext).
-encrypted = JWE.encrypt(payload, key, copyright: 'This is my stuff! All rights reserved')
+encrypted = JWE.encrypt(payload, key, copyright: "This is my stuff! All rights reserved")
 puts encrypted
+
+plaintext, header = JWE.decrypt(encrypted, key)
+puts header[:copyright] #"This is my stuff! All rights reserved"
 ```
 
 ## Available Algorithms

--- a/jwe.gemspec
+++ b/jwe.gemspec
@@ -20,5 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'simplecov-json'
   s.add_development_dependency 'codeclimate-test-reporter'
+  s.add_development_dependency 'codacy-coverage'
 end

--- a/lib/jwe.rb
+++ b/lib/jwe.rb
@@ -46,7 +46,7 @@ module JWE
 
       plaintext = cipher.decrypt(ciphertext, payload.split('.').first)
 
-      apply_zip(header, plaintext, :decompress)
+      [apply_zip(header, plaintext, :decompress), header]
     end
 
     def check_params(header, key)

--- a/lib/jwe/version.rb
+++ b/lib/jwe/version.rb
@@ -1,3 +1,3 @@
 module JWE
-  VERSION = '0.4.0'.freeze
+  VERSION = '1.4.0'.freeze
 end

--- a/spec/jwe/alg_spec.rb
+++ b/spec/jwe/alg_spec.rb
@@ -1,9 +1,4 @@
-require 'jwe/alg/dir'
-require 'jwe/alg/rsa_oaep'
-require 'jwe/alg/rsa15'
-require 'jwe/alg/a128_kw'
-require 'jwe/alg/a192_kw'
-require 'jwe/alg/a256_kw'
+require 'spec_helper'
 require 'openssl'
 
 describe JWE::Alg do

--- a/spec/jwe/base64_spec.rb
+++ b/spec/jwe/base64_spec.rb
@@ -1,4 +1,4 @@
-require 'jwe/base64'
+require 'spec_helper'
 
 module JWE
   describe Base64 do

--- a/spec/jwe/enc_spec.rb
+++ b/spec/jwe/enc_spec.rb
@@ -1,9 +1,4 @@
-require 'jwe/enc/a128cbc_hs256'
-require 'jwe/enc/a192cbc_hs384'
-require 'jwe/enc/a256cbc_hs512'
-require 'jwe/enc/a128gcm'
-require 'jwe/enc/a192gcm'
-require 'jwe/enc/a256gcm'
+require 'spec_helper'
 
 describe JWE::Enc do
   describe '.for' do

--- a/spec/jwe/serialization_spec.rb
+++ b/spec/jwe/serialization_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe JWE::Serialization::Compact do
   describe '#encode' do
     it 'returns components base64ed and joined with a dot' do

--- a/spec/jwe/zip_spec.rb
+++ b/spec/jwe/zip_spec.rb
@@ -1,4 +1,4 @@
-require 'jwe/zip/def'
+require 'spec_helper'
 
 describe JWE::Zip do
   describe '.for' do

--- a/spec/jwe_spec.rb
+++ b/spec/jwe_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe JWE do
   let(:plaintext) { 'The true sign of intelligence is not knowledge but imagination.' }
   let(:rsa_key) { OpenSSL::PKey::RSA.new File.read(File.dirname(__FILE__) + '/keys/rsa.pem') }

--- a/spec/jwe_spec.rb
+++ b/spec/jwe_spec.rb
@@ -7,7 +7,7 @@ describe JWE do
 
   it 'roundtrips' do
     encrypted = JWE.encrypt(plaintext, rsa_key)
-    result = JWE.decrypt(encrypted, rsa_key)
+    result, header = JWE.decrypt(encrypted, rsa_key)
 
     expect(result).to eq plaintext
   end
@@ -15,7 +15,7 @@ describe JWE do
   describe 'when using DEF compression' do
     it 'roundtrips' do
       encrypted = JWE.encrypt(plaintext, rsa_key, zip: 'DEF')
-      result = JWE.decrypt(encrypted, rsa_key)
+      result, header = JWE.decrypt(encrypted, rsa_key)
 
       expect(result).to eq plaintext
     end
@@ -25,7 +25,7 @@ describe JWE do
     it 'roundtrips' do
       aes_password = SecureRandom.random_bytes(16)
       encrypted = JWE.encrypt(plaintext, aes_password, alg: 'dir')
-      result = JWE.decrypt(encrypted, aes_password)
+      result, header = JWE.decrypt(encrypted, aes_password)
 
       expect(result).to eq plaintext
     end
@@ -34,9 +34,7 @@ describe JWE do
   describe 'when using extra headers' do
     it 'roundtrips' do
       encrypted = JWE.encrypt(plaintext, rsa_key, kid: 'some-kid-1')
-      result = JWE.decrypt(encrypted, rsa_key)
-      header, = JWE::Serialization::Compact.decode(encrypted)
-      header = JSON.parse(header)
+      result, header = JWE.decrypt(encrypted, rsa_key)
 
       expect(header['kid']).to eq 'some-kid-1'
       expect(result).to eq plaintext

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,18 @@
 require 'rspec'
 require 'simplecov'
+require 'simplecov-json'
+require 'codeclimate-test-reporter'
+require 'codacy-coverage'
 
 require 'jwe'
+
+Codacy::Reporter.start
+
+SimpleCov.configure do
+  root File.join(File.dirname(__FILE__), '..')
+  project_name 'Ruby JWE - Ruby JSON Web Encryption implementation'
+  add_filter 'spec'
+end
 
 SimpleCov.start if ENV['COVERAGE']
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,9 @@
-require 'simplecov'
-SimpleCov.start
-
 require 'rspec'
+require 'simplecov'
+
 require 'jwe'
+
+SimpleCov.start if ENV['COVERAGE']
 
 RSpec.configure do |config|
   config.order = 'random'


### PR DESCRIPTION
The original decrypt method only returns the decrypted payload and makes it difficult to get to the header information without going through a bunch of hoops. Returning the payload and header from this method makes more sense since it's more generalized and allows for more flexibility.