### PR TITLE
Add RSA-OAEP-256 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Only a subset of these algorithms is implemented in this gem. Striked elements a
 Key management:
 * RSA1_5
 * RSA-OAEP (default)
-* ~~RSA-OAEP-256~~
+* RSA-OAEP-256
 * A128KW
 * A192KW
 * A256KW

--- a/lib/jwe/alg.rb
+++ b/lib/jwe/alg.rb
@@ -3,6 +3,7 @@ require 'jwe/alg/a192_kw'
 require 'jwe/alg/a256_kw'
 require 'jwe/alg/dir'
 require 'jwe/alg/rsa_oaep'
+require 'jwe/alg/rsa_oaep_256'
 require 'jwe/alg/rsa15'
 
 module JWE

--- a/lib/jwe/alg/rsa_oaep_256.rb
+++ b/lib/jwe/alg/rsa_oaep_256.rb
@@ -1,6 +1,6 @@
 module JWE
   module Alg
-    # RSA-OAEP key encryption algorithm.
+    # RSA-OAEP-256 key encryption algorithm.
     class RsaOaep256
       attr_accessor :key
 

--- a/lib/jwe/alg/rsa_oaep_256.rb
+++ b/lib/jwe/alg/rsa_oaep_256.rb
@@ -1,0 +1,20 @@
+module JWE
+  module Alg
+    # RSA-OAEP key encryption algorithm.
+    class RsaOaep256
+      attr_accessor :key
+
+      def initialize(key)
+        self.key = key
+      end
+
+      def encrypt(cek)
+        key.public_encrypt(cek, OpenSSL::PKey::RSA::PKCS1_OAEP_PADDING)
+      end
+
+      def decrypt(encrypted_cek)
+        key.private_decrypt(encrypted_cek, OpenSSL::PKey::RSA::PKCS1_OAEP_PADDING)
+      end
+    end
+  end
+end

--- a/spec/jwe/alg_spec.rb
+++ b/spec/jwe/alg_spec.rb
@@ -53,6 +53,21 @@ describe JWE::Alg::RsaOaep do
   end
 end
 
+describe JWE::Alg::RsaOaep256 do
+  let(:alg) { JWE::Alg::RsaOaep256.new(key) }
+
+  describe '#encrypt' do
+    it 'returns an encrypted string' do
+      expect(alg.encrypt('random key')).to_not eq 'random key'
+    end
+  end
+
+  it 'decrypts the encrypted key to the original key' do
+    ciphertext = alg.encrypt('random key')
+    expect(alg.decrypt(ciphertext)).to eq 'random key'
+  end
+end
+
 describe JWE::Alg::Rsa15 do
   let(:alg) { JWE::Alg::Rsa15.new(key) }
 


### PR DESCRIPTION
Adds support for RSA-OAEP-256 algorithm. Tested in RSpec and also with our company's testing RSA-OAEP-256 key pair.