### PR TITLE
Support Ruby 3.4

### DIFF
--- a/jwe.gemspec
+++ b/jwe.gemspec
@@ -17,4 +17,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5.0'
   s.metadata['rubygems_mfa_required'] = 'true'
+
+  s.add_dependency 'base64'
 end

--- a/lib/jwe/alg/aes_kw.rb
+++ b/lib/jwe/alg/aes_kw.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'jwe/enc/cipher'
 
 module JWE
@@ -8,13 +10,13 @@ module JWE
       attr_accessor :iv
 
       def initialize(key = nil, iv = "\xA6\xA6\xA6\xA6\xA6\xA6\xA6\xA6")
-        self.iv = iv.force_encoding('ASCII-8BIT')
-        self.key = key.force_encoding('ASCII-8BIT')
+        self.iv = iv.b
+        self.key = key.b
       end
 
       def encrypt(cek)
         a = iv
-        r = cek.force_encoding('ASCII-8BIT').scan(/.{8}/m)
+        r = cek.b.scan(/.{8}/m)
 
         6.times do |j|
           a, r = kw_encrypt_round(j, a, r)
@@ -36,7 +38,7 @@ module JWE
       end
 
       def decrypt(encrypted_cek)
-        c = encrypted_cek.force_encoding('ASCII-8BIT').scan(/.{8}/m)
+        c = encrypted_cek.b.scan(/.{8}/m)
         a, *r = c
 
         5.downto(0) do |j|


### PR DESCRIPTION
Disclaimer: I'm not that familiar with this gem. Simply trying to address Ruby 3.4 issues as it will be released in a few days and the amount of warning messages when running our application on Ruby 3.4 is quite large. Thankfully the fixes seem pretty straightforward.

1. Add `base64` to the Gemspec as a runtime dependency as it's no longer a default gem as of Ruby 3.4.
2. Add `frozen_string_literal: true` directive and `dup` all strings that we attempt to modify in place with `force_encoding` as in place string modification is forbidden with said directive in place.

Resolves https://github.com/jwt/ruby-jwe/issues/25