### PR TITLE
Fix README CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JWE
 
-[![Build Status](https://github.com/jwt/ruby-jwe/workflows/test/badge.svg?branch=master)](https://github.com/jwt/ruby-jwe/actions)
+[![Build Status](https://github.com/jwt/ruby-jwe/actions/workflows/test.yml/badge.svg)](https://github.com/jwt/ruby-jwe/actions/workflows/test.yml)
 [![Gem Version](https://badge.fury.io/rb/jwe.svg)](https://badge.fury.io/rb/jwe)
 
 A ruby implementation of the [RFC 7516 JSON Web Encryption (JWE)](https://tools.ietf.org/html/rfc7516) standard.


### PR DESCRIPTION
Simply fixing the broken CI badge in the README.

Current

![image](https://github.com/user-attachments/assets/86ad5fae-8783-4387-95a7-82dc4f13d460)

Proposed

![image](https://github.com/user-attachments/assets/7b440633-9f73-4587-b371-b59a07f5c806)

Fetched the markup from this GitHub Actions page button. (top right corner)

![Screenshot From 2025-02-16 18-06-48](https://github.com/user-attachments/assets/1ec99899-a122-4a03-ab20-81f75d4be8c0)
