### PR TITLE
Fix: Rescue OpenSSL::Cipher::CipherError for unsupported cipher algorithms

### DIFF
--- a/lib/jwe/enc/cipher.rb
+++ b/lib/jwe/enc/cipher.rb
@@ -7,7 +7,7 @@ module JWE
       class << self
         def for(cipher_name)
           OpenSSL::Cipher.new(cipher_name)
-        rescue RuntimeError
+        rescue RuntimeError, OpenSSL::Cipher::CipherError
           raise JWE::NotImplementedError.new("The version of OpenSSL linked to your Ruby does not support the cipher #{cipher_name}.")
         end
       end


### PR DESCRIPTION
## Summary

Fix error handling in `JWE::Enc::Cipher.for` to properly catch unsupported cipher errors.

## Problem

When an unsupported cipher algorithm is used, newer versions of OpenSSL raise `OpenSSL::Cipher::CipherError` instead of `RuntimeError`. This caused 6 test failures because the expected `JWE::NotImplementedError` was not being raised.

## Solution

Added `OpenSSL::Cipher::CipherError` to the rescue clause alongside the existing `RuntimeError` to handle both cases.