### PR TITLE
Pin GitHub Actions to commit SHAs for improved security

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
     name: RuboCop
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@90be1154f987f4dc0fe0dd0feedac9e473aa4ba8 # v1
         with:
           ruby-version: "ruby"
           bundler-cache: true
@@ -39,10 +39,10 @@ jobs:
           - "3.4"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@90be1154f987f4dc0fe0dd0feedac9e473aa4ba8 # v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true


### PR DESCRIPTION
## Summary

Pin all GitHub Actions dependencies to their full commit SHAs instead of mutable version tags to mitigate supply chain attacks.

## Changes

- `actions/checkout@v6` → `actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8`
- `ruby/setup-ruby@v1` → `ruby/setup-ruby@90be1154f987f4dc0fe0dd0feedac9e473aa4ba8`

## Why

Using version tags (e.g., `@v6`) leaves workflows vulnerable to supply chain attacks, as tags are mutable and can be modified by attackers who gain write access to an action's repository. Pinning to commit SHAs ensures immutable references.

See: [CVE-2025-30066](https://www.cve.org/CVERecord?id=CVE-2025-30066)